### PR TITLE
Corrige elemento neutro na operação xor

### DIFF
--- a/sigilo-perfeito.tex
+++ b/sigilo-perfeito.tex
@@ -201,7 +201,7 @@ Nos próximos capítulos apresentaremos definições de segurança mais fracas e
 \label{sec:exercicio}
 
 \begin{exercicio}
-  Mostre que o $1$ é elementro neutro na operação $\xor$, ou seja, que para todo $x \in \{0,1\}^*$ temos que $x \xor 1 = 1 \xor x = x$.
+  Mostre que o $0$ é elementro neutro na operação $\xor$, ou seja, que para todo $x \in \{0,1\}^*$ temos que $x \xor 0 = 0 \xor x = x$.
 \end{exercicio}
 
 \begin{exercicio}


### PR DESCRIPTION
Na operação Xor, o elemento neutro é 0, e não 1 (como o exercício pede para mostrar).
Podemos quebrar o exemplo do exercício ao escolher x = 1

x xor 1 = 1 xor x = x
1 xor 1 = 1 xor 1 = 1 // Errado! 1 xor 1 é 0!

No entanto, a propriedade funciona para zero:
x xor 0 = 0 xor x = x
1 xor 0 = 0 xor 1 = 1 // x escolhido foi 1
0 xor 0 = 0 xor 0 = 0 // x escolhido foi 0