### PR TITLE
Corrige exercício de operação xor

### DIFF
--- a/sigilo-perfeito.tex
+++ b/sigilo-perfeito.tex
@@ -213,7 +213,7 @@ Nos próximos capítulos apresentaremos definições de segurança mais fracas e
 \end{exercicio}
 
 \begin{exercicio}
-  Mostre que para qualquer sequência de bits $x \in \{0,1\}^*$ temos que $x \xor x = 1$.
+  Mostre que para qualquer sequência de bits $x \in \{0,1\}^*$ temos que $x \xor x = 0$.
 \end{exercicio}
 
 \begin{exercicio}


### PR DESCRIPTION
Na mesma linha do PR #12, o exemplo do exercício pode ser facilmente quebrado (está invertido):

010 xor 010 = 000
111 xor 111 = 000
001 xor 001 = 000

Por que sempre que o número em X for 1, o valor que será operado com ele tambem será 1 (1 xor 1), e o resultado disso é sempre zero.

Ao duplicarmos X, não existe nenhum caso onde teremos x[n] != x[n], portanto nunca teremos 1 e 0. Sempre 1 e 1 ou 0 e 0